### PR TITLE
WD-3806, fix nginx crashing issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Developer Changelog
 
+## January 7, 2022
+* fix log volume issue for nginx reverse proxy
+* flesh out readmes a bit more
+
 ### January 4, 2022
 * update pullrequest template
 * updated docker-compose file to include db variables

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ If you have Docker:
 cd gdx-agreements-tracker
 docker compose up --build -d
 ```
+
+**Note**: If this is your first time starting the app, you can populate the database by running the provided migrations and seeders. See the README within the backend directory for more information.
+
 The app is then available at [http://localhost/](http://localhost/). For your reference, the API is available at [http://localhost/api/](http://localhost/api/). The websocket for the frontend react is available at http://localhost:3000/ and as long as the `frontend/.env` file (or other similar facility) specifies the WDS_SOCKET_PORT as 3000, the React live-refresh-upon-code-change feature should work in your browser. 
 
 Logs end up in `docker/logs/` in `backend`, `frontend`, and `nginx` subdirectories for your debugging convenience.

--- a/backend/README.md
+++ b/backend/README.md
@@ -28,6 +28,16 @@ it("tests an asynchronous function", async () => {
 ```
 
 ## Database
+
+To connect to a database GUI tool during development, use the following parameters:
+
+- Server host: `localhost`
+- Server port: `15432`
+- Username: `postgres`
+- Password: `postgres`
+
+If using the docker-compose.yml file to develop locally, you'll need to populate your database once the containers are up and running. Make sure to run these migrate and seed commands from within the `backend` directory so that the knex command can find `knexfile.js`.
+
 #### Migrations
 * Create a new migration:
     * `docker compose exec backend npx knex migrate:make <name_of_migration>`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
         volumes:
             - ./frontend/build:/var/www
             - ./web/nginx.conf:/etc/nginx/nginx.conf
-            - ./docker/log:/var/log
+            - ./docker/log/web:/var/log/nginx
         #depends_on:
         #    - backend
         #    - frontend


### PR DESCRIPTION
# Pull Request Considerations

Although some of these things can only be done after merged, please ensure all items have been considered when doing pull requests.

Context: I am curious to see how many of us were experiencing this issue, which is described in the ticket: https://apps.itsm.gov.bc.ca/jira/browse/WD-3806

The solution was indeed to change the `web` service's 3rd volume to `./docker/log/web:/var/log/nginx`. It could be that in some instances, the volume gets mounted before nginx has a chance to create or set up permissions for `access.log` and `error.log`. I think what happens is when the volume is created, the local docker/logs folder gets copied over to /var/log and nginx then doesn't have the permissions to make an nginx folder nor access.log, error.log.
