### PR TITLE
add database migrations to api container startup in openshift.

### DIFF
--- a/.github/workflows/api-build.yaml
+++ b/.github/workflows/api-build.yaml
@@ -6,8 +6,10 @@ on:
     paths:
       - "backend/**/*"
       - "!backend/.eslintrc.json"
-      - "!backend/Dockerfile"
+      - "!backend/Dockerfile*"
       - "!backend/.dockerignore"
+      - "!backend/docs"
+      - "!backend/README.md"
 
   workflow_dispatch:
 defaults:

--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -5,10 +5,12 @@ on:
       - development
     paths:
       - "frontend/**/*"
-      - "!frontend/Dockerfile"
+      - "!frontend/Dockerfile*"
       - "!frontend/tsconfig.json"
       - "!frontend/tslint.json"
       - "!frontend/.prettierrc.js"
+      - "!frontend/docs"
+      - "!frontend/README.md"
 
   workflow_dispatch:
 defaults:

--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -11,6 +11,7 @@ on:
       - "!frontend/.prettierrc.js"
       - "!frontend/docs"
       - "!frontend/README.md"
+      - "!frontend/.dockerignore"
 
   workflow_dispatch:
 defaults:

--- a/.github/workflows/app-tests.yml
+++ b/.github/workflows/app-tests.yml
@@ -6,10 +6,12 @@ on:
     paths:
       - "frontend/**/*"
       - "!frontend/Dockerfile*"
-      - "!frontend/Docker/*"
       - "!frontend/tsconfig.json"
       - "!frontend/tslint.json"
       - "!frontend/.prettierrc.js"
+      - "!frontend/docs"
+      - "!frontend/README.md"
+      - "!frontend/.dockerignore"
 
   workflow_dispatch:
 defaults:
@@ -44,5 +46,3 @@ jobs:
 
       - name: Run Tests
         run: npm run test
-
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Developer Changelog
-### January 11, 2022 WD-3815 part 2
+### January 14, 2022 WD-3815 part 3
+* backend
+    * added logging for when connected to database, but the schema is wrong
+* openshift
+    * api
+      * attempt a database migration to the latest migration on startup 
+    * templates: a build automation fix
+* github workflows
+  * fix overlooked item: don't rebuild containers on non-code file changes
+* local dev environment
+  * fix overlooked item: don't copy new transients into container builds
+
+### January 12, 2022 WD-3815 part 2
 * backend
     * added info to log about database being connected to
 * openshift

--- a/backend/src/facilities/daemon.js
+++ b/backend/src/facilities/daemon.js
@@ -55,6 +55,8 @@ const initializeConnections = () => {
 
       if (state.connections.data) {
         log.info('DatabaseConnection Reachable', { function: 'initializeConnections' });
+      } else {
+        log.info('DatabaseConnection Connected but not ready', { function: 'initializeConnections' });
       }
     })
     .catch(error => {

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,5 +1,4 @@
 node_modules/
-test/
 docs/
 
 Dockerfile*

--- a/openshift/s2i/nodejs/Dockerfile.api
+++ b/openshift/s2i/nodejs/Dockerfile.api
@@ -1,0 +1,52 @@
+# Base alpine images with node.js
+FROM node:16-alpine
+
+ENV BUILDER_VERSION 1.0
+
+LABEL io.k8s.description="Platform for building Node.js Applications" \
+      io.k8s.display-name="builder nodejs" \
+      io.openshift.expose-services="3000:http" \
+      io.openshift.tags="builder,nodejs"
+
+# Defines the location of the S2I
+# Although this is defined in openshift/base-centos7 image it's repeated here
+# to make it clear why the following COPY operation is happening
+LABEL io.openshift.s2i.scripts-url=image:///usr/local/s2i
+
+# Copy S2I base files to the image.
+COPY ./s2i/root/ /
+
+# Copy the S2I scripts from ./s2i/api/ to /usr/local/s2i for the API runtime image.
+COPY ./s2i/api/ /usr/local/s2i
+
+ENV \
+    # The $HOME is not set by default, but some applications needs this variable
+    HOME=/opt/app-root/ \
+    PATH=/opt/app-root/src/bin:/opt/app-root/bin:$PATH
+
+# When bash is started non-interactively, to run a shell script, for example it
+# looks for this variable and source the content of this file. This will enable
+# the SCL for all scripts without need to do 'scl enable'.
+ENV BASH_ENV=/opt/app-root/etc/scl_enable \
+    ENV=/opt/app-root/etc/scl_enable \
+    PROMPT_COMMAND=". /opt/app-root/etc/scl_enable"
+
+# Drop the root user and make the content of /opt/app-root owned by user 1001
+#RUN useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin -c "Default Application User" default
+RUN mkdir -p /opt/app-root/
+RUN adduser -u 1001 -g 0 -D -h ${HOME} -s /sbin/nologin nodejs
+RUN chown -R 1001:0 /opt/app-root
+#RUN chown -R 1001:1001 /opt/app-root
+
+# This default user is created in the alpine image
+USER 1001
+
+# Set the default port for applications built using this image
+EXPOSE 3000
+
+# Directory with the sources is set as the working directory so all STI scripts
+# can execute relative to this path.
+WORKDIR ${HOME}
+
+# Set the default CMD for the image
+CMD ["usage"]

--- a/openshift/s2i/nodejs/s2i/api/run
+++ b/openshift/s2i/nodejs/s2i/api/run
@@ -1,0 +1,12 @@
+#!/bin/sh -e
+#
+# S2I run script for the 'lighttpd-centos7' image.
+# The run script executes the server that runs your application.
+#
+# For more information see the documentation:
+#	https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md
+#
+
+npx knex migrate:latest
+
+exec node src/server.js

--- a/openshift/templates/api/build.yaml
+++ b/openshift/templates/api/build.yaml
@@ -175,7 +175,7 @@ objects:
           imageChange:
             from:
               kind: "ImageStreamTag"
-              name: "${APP_NAME}-${ROLE_NAME}-build.${GIT_REF}:latest"
+              name: "${APP_NAME}-${ROLE_NAME}-build.${GIT_REF}:${OUTPUT_IMAGE_TAG}"
         - type: ConfigChange
       source:
         type: Dockerfile


### PR DESCRIPTION
* backend
    * added logging for when connected to database, but the schema is wrong
* openshift
    * api
      * attempt a database migration to the latest migration on startup 
    * templates: a build automation fix
* github workflows
  * fix overlooked item: don't rebuild containers on non-code file changes
* local dev environment
  * fix overlooked item: don't copy new transients into container builds