### PR TITLE
add support for colima by moving database to volume.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Developer Changelog
 
+### March 11, 2022, 2022 DESCW-201
+* fixes to make `docker compose up` work with (co)lima.
+  * this change moves the database storage volume inside the VM, so your database will be blank; don't forget to:
+    * `docker compose exec backend npx knex migrate:latest`
+    * `docker compose exec backend npx knex seed:run`
+
 ### February 1, 2022, 2022 WD-3678
 * frontend
     * added new table component from MUI

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,12 +11,18 @@ x-env:
   POSTGRES_PORT: &POSTGRES_PORT 5432
   POSTGRES_DATABASE: &POSTGRES_DATABASE gat_db
   DATABASE_AUTO_DEPLOY: &DATABASE_AUTO_DEPLOY 1
+volumes:
+  database:
 services:
   frontend:
     build:
       context: frontend/
       dockerfile: Dockerfile.dev
     restart: always
+    environment:
+      # large node_modules directories exhaust all of the file watchers in docker. poll instead.
+      # see: https://github.com/facebook/create-react-app/issues/1049#issuecomment-261731734
+      CHOKIDAR_USEPOLLING: true
     command:
       [
         "sh",
@@ -68,7 +74,7 @@ services:
       POSTGRES_PASSWORD: *POSTGRES_PASSWORD
       POSTGRES_USER: *POSTGRES_USER
     volumes:
-      - ./docker/postgres:/var/lib/postgresql/data
+      - database:/var/lib/postgresql/data
     networks:
       - gat-db
     ports:


### PR DESCRIPTION
moved the database volume to a native docker volume instead of a host mount. same as what we did for wordpress. there was another colima problem related to react compilation. i solved that too.