### PR TITLE
Feature/descw 563 route validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Developer Changelog
 
+### September 7, 2022 (DESCW-563) Route Validators
+- Backend
+  - Added fluent-json-schema dependency to package.json (need to `run npm install`)
+  - Created validators/common_schema to provide helpers for validators
+  - Added input validation and response serialization for change_request, projects, contacts, users routes
+
 ### August 31, 2022 (DESCW-587) Project Agreements
 - Backend
   - Added input validation for agreements fields

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,12 +31,13 @@
     "fastify-auth": "^1.1.0",
     "fastify-cors": "^6.0.2",
     "fastify-plugin": "^3.0.0",
+    "fluent-json-schema": "^3.1.0",
     "jsonwebtoken": "^8.5.1",
     "jwks-client": "^1.4.0",
     "knex": "^0.95.14",
+    "n-readlines": "^1.0.1",
     "pg": "^8.7.1",
-    "pino": "^7.6.0",
-    "n-readlines": "^1.0.1"
+    "pino": "^7.6.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.22.0",

--- a/backend/src/routes/change_request.js
+++ b/backend/src/routes/change_request.js
@@ -6,22 +6,25 @@ const routes = [
   {
     method: "GET",
     url: `/projects/:projectId/${what}`,
+    schema: validators.getAll,
     handler: controller.getAll,
   },
   {
     method: "GET",
     url: `/projects/:projectId/${what}/:changeRequestId`,
-    schema: validators.getOneValidator,
+    schema: validators.getOne,
     handler: controller.getOne,
   },
   {
     method: "PUT",
     url: `/${what}/:id`,
+    schema: validators.updateOne,
     handler: controller.updateOne,
   },
   {
     method: "POST",
     url: `/${what}`,
+    schema: validators.addOne,
     handler: controller.addOne,
   },
 ];

--- a/backend/src/routes/contacts.js
+++ b/backend/src/routes/contacts.js
@@ -6,24 +6,25 @@ const routes = [
   {
     method: "GET",
     url: `/${what}`,
+    schema: validators.getAll,
     handler: controller.getAll,
   },
   {
     method: "GET",
     url: `/${what}/:id`,
-    schema: validators.getOneValidator,
+    schema: validators.getOne,
     handler: controller.getOne,
   },
   {
     method: "PUT",
     url: `/${what}/:id`,
-    schema: validators.updateOneValidator,
+    schema: validators.updateOne,
     handler: controller.updateOne,
   },
   {
     method: "POST",
     url: `/${what}`,
-    schema: validators.addOneValidator,
+    schema: validators.addOne,
     handler: controller.addOne,
   },
 ];

--- a/backend/src/routes/projects.js
+++ b/backend/src/routes/projects.js
@@ -6,6 +6,7 @@ const routes = [
   {
     method: "GET",
     url: `/${what}`,
+    schema: validators.getAll,
     handler: controller.getAll,
   },
   {
@@ -23,13 +24,12 @@ const routes = [
   {
     method: "GET",
     url: `/${what}/:projectId/close-out`,
-    schema: validators.getOne,
+    schema: validators.getOneCloseOut,
     handler: controller.getCloseOut,
   },
   {
     method: "POST",
     url: `/${what}/:projectId/close-out/notify`,
-    schema: validators.getOne,
     handler: controller.notifyCloseOut,
   },
 ];

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -6,6 +6,7 @@ const routes = [
   {
     method: "GET",
     url: `/${what}`,
+    schema: validators.getAll,
     handler: controller.getAll,
   },
   {

--- a/backend/src/validators/change_request.js
+++ b/backend/src/validators/change_request.js
@@ -1,23 +1,54 @@
-const getOneValidator = {
-  // Request parameters.
-  params: {
-    changeRequestId: { type: "string" },
-    projectId: { type: "string" },
-  },
-  // Response validation.
-  response: {
-    200: {
-      type: "object",
-      properties: {
-        data: {
-          changeRequestId: { type: "integer" },
-          projectId: { type: "string" },
-        },
-      },
-    },
-  },
+const { Schema, getResponse, getUpdateResponse, getAddResponse } = require("./common_schema.js");
+const S = require("fluent-json-schema");
+
+const baseBody = S.object()
+  .prop("id", Schema.Id)
+  .prop("version", Schema.ShortString)
+  .prop("initiation_date", Schema.Date)
+  .prop("cr_contact", Schema.ShortString)
+  .prop("initiated_by", Schema.ShortString)
+  .prop("fiscal_year", Schema.ShortString)
+  .prop("summary", S.string())
+  .prop("approval_date", Schema.Date)
+  .prop("link_id", Schema.Id);
+
+const requestBody = baseBody
+  .without(["id", "link_id", "version", "fiscal_year", "initiated_by"])
+  .prop("fiscal_year", Schema.Id)
+  .prop("initiated_by", Schema.Enum(["GDX", "Client", null]));
+
+const getAll = {
+  params: S.object().prop("projectId", Schema.Id),
+  response: getResponse(S.array().items(baseBody)),
+};
+
+const getOne = {
+  params: S.object().prop("changeRequestId", Schema.Id).prop("projectId", Schema.Id),
+  response: getResponse(
+    S.array().items(
+      baseBody
+        .without(["initiated_by", "fiscal_year"])
+        .prop("initiated_by", Schema.Picker)
+        .prop("fiscal_year", Schema.Picker)
+    )
+  ),
+};
+
+const updateOne = {
+  params: S.object().prop("changeRequestId", Schema.Id).prop("projectId", Schema.Id),
+  body: requestBody,
+  response: getUpdateResponse(),
+};
+
+const addOne = {
+  params: S.object().prop("projectId", Schema.Id),
+  body: requestBody,
+  response: getAddResponse(),
 };
 
 module.exports = {
-  getOneValidator,
+  getAll,
+  getOne,
+  updateOne,
+  addOne,
 };

--- a/backend/src/validators/change_request.js
+++ b/backend/src/validators/change_request.js
@@ -13,6 +13,7 @@ const baseBody = S.object()
   .prop("link_id", Schema.Id);
 
 const requestBody = baseBody
+  .minProperties(1)
   .without(["id", "link_id", "version", "fiscal_year", "initiated_by"])
   .prop("fiscal_year", Schema.Id)
   .prop("initiated_by", Schema.Enum(["GDX", "Client", null]));

--- a/backend/src/validators/common_schema.js
+++ b/backend/src/validators/common_schema.js
@@ -1,0 +1,68 @@
+const S = require("fluent-json-schema");
+
+const Id = S.integer().minimum(0);
+
+const MaxStringLength = 255;
+
+/**
+ * Collection of commonly used field validations.
+ */
+const Schema = {
+  Money: S.oneOf([S.number().multipleOf(0.01), S.const("")]),
+  Date: S.oneOf([S.string().format(S.FORMATS.DATE_TIME), S.const(null)]),
+  Email: S.oneOf([S.string().format(S.FORMATS.EMAIL), S.const(null)]),
+  RequiredEmail: S.string().format(S.FORMATS.EMAIL).minLength(1),
+  Id: Id,
+  IdParam: S.object().prop("id", Id),
+  Phone: S.oneOf([S.string().pattern("^[0-9]{3} [0-9]{3}-[0-9]{4}$"), S.const(null)]),
+  Picker: S.object()
+    .prop("value", S.oneOf([Id, S.string()]))
+    .prop("label", S.string()),
+  ShortString: S.string().maxLength(MaxStringLength),
+  Uri: S.oneOf([S.string().format(S.FORMATS.URI), S.const(null)]),
+  Enum: (list) => {
+    return S.enum(list);
+  },
+};
+
+/**
+ * Default response including user data.
+ *
+ * @param   {any} data Response data to attach to response.
+ * @returns {any}      response
+ */
+const getResponse = (data) => {
+  return {
+    "2xx": S.object()
+      .prop("data", data)
+      .prop(
+        "user",
+        S.object()
+          .prop("capabilities", S.array().items(S.string()))
+          .prop("email", S.string())
+          .prop("name", S.string())
+          .prop("preferred_username", S.string())
+          .prop("roles", S.array().items(S.string()))
+      ),
+    default: S.object().prop("data", S.object().prop("message", S.string())),
+  };
+};
+
+/**
+ * Default add response returning rowCount.
+ */
+const getAddResponse = () => {
+  getResponse(S.object().prop("rowCount", S.integer()));
+};
+
+/**
+ * Default update response returning id.
+ */
+const getUpdateResponse = () => {
+  getResponse(Schema.Id);
+};
+
+exports.Schema = Schema;
+exports.getResponse = getResponse;
+exports.getAddResponse = getAddResponse;
+exports.getUpdateResponse = getUpdateResponse;

--- a/backend/src/validators/contacts.js
+++ b/backend/src/validators/contacts.js
@@ -1,65 +1,59 @@
-const REQUIRED_STRING_VALIDATION = { type: "string", minLength: 1, maxLength: 255 };
-const OPTIONAL_STRING_VALIDATION = { type: "string", maxLength: 255 };
-const BODY_PROPERTY_VALIDATIONS = {
-  last_name: REQUIRED_STRING_VALIDATION,
-  first_name: REQUIRED_STRING_VALIDATION,
-  email: OPTIONAL_STRING_VALIDATION,
-  contact_phone: OPTIONAL_STRING_VALIDATION,
-  contact_title: OPTIONAL_STRING_VALIDATION,
-  ministry_id: { type: "integer", minimum: 0 },
-  business_area_id: { type: "integer" },
-  address: OPTIONAL_STRING_VALIDATION,
-  city: OPTIONAL_STRING_VALIDATION,
-  province: OPTIONAL_STRING_VALIDATION,
-  postal: OPTIONAL_STRING_VALIDATION,
-  country: OPTIONAL_STRING_VALIDATION,
-  website: OPTIONAL_STRING_VALIDATION,
-  mobile: OPTIONAL_STRING_VALIDATION,
-  fax: OPTIONAL_STRING_VALIDATION,
-  notes: { type: "string" },
+const { Schema, getResponse, getAddResponse, getUpdateResponse } = require("./common_schema.js");
+const S = require("fluent-json-schema");
+
+const multiBody = S.array().items(
+  S.object()
+    .prop("id", Schema.Id)
+    .prop("last_name", Schema.ShortString)
+    .prop("first_name", Schema.ShortString)
+    .prop("contact_title", Schema.ShortString)
+    .prop("ministry_short_name", Schema.ShortString)
+);
+
+const baseSingleBody = S.object()
+  .prop("id", Schema.Id)
+  .prop("last_name", Schema.ShortString.minLength(1))
+  .prop("first_name", Schema.ShortString.minLength(1))
+  .prop("email", Schema.Email)
+  .prop("contact_phone", Schema.Phone)
+  .prop("contact_title", Schema.ShortString)
+  .prop("business_area_id", Schema.Id)
+  .prop("address", Schema.ShortString)
+  .prop("city", Schema.ShortString)
+  .prop("province", Schema.ShortString)
+  .prop("postal", Schema.ShortString)
+  .prop("country", Schema.ShortString)
+  .prop("website", Schema.Uri)
+  .prop("mobile", Schema.Phone)
+  .prop("fax", Schema.Phone)
+  .prop("notes", S.string());
+
+const requestSingleBody = baseSingleBody.prop("ministry_id", Schema.Id);
+const responseSingleBody = baseSingleBody.prop("ministry_id", Schema.Picker);
+
+const getAll = {
+  response: getResponse(multiBody),
 };
 
-const getOneValidator = {
-  // Request parameters.
-  params: {
-    id: { type: "integer" },
-  },
-  // Response validation.
-  response: {
-    200: {
-      type: "object",
-      properties: {
-        data: {
-          id: { type: "integer" },
-        },
-      },
-    },
-  },
+const getOne = {
+  params: Schema.IdParam,
+  response: getResponse(responseSingleBody),
 };
 
-const updateOneValidator = {
-  // Request parameters.
-  params: {
-    id: { type: "integer" },
-  },
-  // Body validation.
-  body: {
-    type: "object",
-    properties: BODY_PROPERTY_VALIDATIONS,
-  },
+const updateOne = {
+  params: Schema.IdParam,
+  body: requestSingleBody,
+  response: getUpdateResponse(),
 };
 
-const addOneValidator = {
-  // Body validation.
-  body: {
-    type: "object",
-    required: ["last_name", "first_name"],
-    properties: BODY_PROPERTY_VALIDATIONS,
-  },
+const addOne = {
+  body: requestSingleBody.required(["first_name", "last_name"]),
+  response: getAddResponse(),
 };
 
 module.exports = {
-  getOneValidator,
-  updateOneValidator,
-  addOneValidator,
+  getAll,
+  getOne,
+  updateOne,
+  addOne,
 };

--- a/backend/src/validators/contacts.js
+++ b/backend/src/validators/contacts.js
@@ -42,7 +42,7 @@ const getOne = {
 
 const updateOne = {
   params: Schema.IdParam,
-  body: requestSingleBody,
+  body: requestSingleBody.minProperties(1),
   response: getUpdateResponse(),
 };
 

--- a/backend/src/validators/projects.js
+++ b/backend/src/validators/projects.js
@@ -1,59 +1,119 @@
-const getOne = {
-  // Request parameters.
-  params: {
-    projectId: { type: "integer" },
-  },
-};
+const { Schema, getResponse, getUpdateResponse } = require("./common_schema.js");
+const S = require("fluent-json-schema");
 
-const requiredStringValidation = { type: "string", minLength: 1, maxLength: 255 };
-const optionalStringValidation = { type: "string", maxLength: 255 };
 const yesNoEnum = ["Yes", "No", "N/A", null];
 
+const requestSingleBody = S.object()
+  // Registration
+  .prop("project_number", Schema.ShortString.minLength(1))
+  .prop("project_name", Schema.ShortString.minLength(1))
+  .prop("project_version", Schema.ShortString)
+  .prop("ministry_id", Schema.Id)
+  .prop("initiation_date", Schema.Date)
+  .prop("portfolio_id", Schema.Id)
+  .prop("planned_start_date", Schema.Date)
+  .prop("fiscal", Schema.Id)
+  .prop("planned_end_date", Schema.Date)
+  .prop("planned_budget", Schema.Money)
+  .prop("project_type", Schema.Enum(["Internal", "External", null]))
+  .prop("project_status", Schema.Enum(["NewRequest", "Active", "Cancelled", "Complete", null]))
+  .prop("funding", Schema.Enum(["Operational", "Capital", "Combination", null]))
+  .prop("total_project_budget", Schema.Money)
+  .prop("recoverable", Schema.Enum(["Fully", "Partially", "Non-Recoverable", null]))
+  .prop("recoverable_amount", Schema.Money)
+  // Agreement
+  .prop(
+    "agreement_type",
+    Schema.Enum(["Project Charter", "Other", "Partnership Agreement", "MOU", null])
+  )
+  .prop("agreement_start_date", Schema.Date)
+  .prop("agreement_signed_date", Schema.Date)
+  .prop("agreement_end_date", Schema.Date)
+  .prop("description", S.string())
+  .prop("notes", S.string())
+  // Close Out
+  .prop("close_out_date", Schema.Date)
+  .prop("completed_by_contact_id", Schema.Id)
+  .prop("actual_completion_date", Schema.Date)
+  .prop("hand_off_to_operations", Schema.Enum(yesNoEnum))
+  .prop("records_filed", Schema.Enum(yesNoEnum))
+  .prop("contract_ev_completed", Schema.Enum(yesNoEnum))
+  .prop("contractor_security_terminated", Schema.Enum(yesNoEnum));
+
+const getAll = {
+  response: getResponse(
+    S.array().items(
+      S.object()
+        .prop("id", Schema.Id)
+        .prop("project_number", Schema.ShortString)
+        .prop("project_name", Schema.ShortString)
+        .prop("project_version", Schema.ShortString)
+        .prop("portfolio_id", Schema.Id)
+        .prop("project_manager", Schema.Id)
+        .prop("agreement_end_date", Schema.Date)
+        .prop("project_status", Schema.ShortString)
+        .prop("initiation_date", Schema.Date)
+    )
+  ),
+};
+
+const getOne = {
+  params: Schema.IdParam,
+  response: getResponse(
+    S.object()
+      .prop("project_number", Schema.ShortString)
+      .prop("project_name", Schema.ShortString)
+      .prop("project_version", Schema.ShortString)
+      .prop("ministry_id", Schema.Picker)
+      .prop("initiation_date", Schema.Date)
+      .prop("portfolio_id", Schema.Picker)
+      .prop("planned_start_date", Schema.Date)
+      .prop("fiscal", Schema.Picker)
+      .prop("planned_end_date", Schema.Date)
+      .prop("planned_budget", Schema.Money)
+      .prop("project_type", Schema.Picker)
+      .prop("project_status", Schema.Picker)
+      .prop("funding", Schema.Picker)
+      .prop("total_project_budget", Schema.Money)
+      .prop("recoverable", Schema.Picker)
+      .prop("recoverable_amount", Schema.Money)
+      .prop("agreement_type", Schema.Picker)
+      .prop("agreement_start_date", Schema.Date)
+      .prop("agreement_signed_date", Schema.Date)
+      .prop("agreement_end_date", Schema.Date)
+      .prop("description", S.string())
+      .prop("notes", S.string())
+      .prop(
+        "contracts",
+        S.array().items(S.object().prop("id", Schema.Id).prop("co_number", Schema.ShortString))
+      )
+  ),
+};
+
+const getOneCloseOut = {
+  params: Schema.IdParam,
+  response: getResponse(
+    S.object()
+      .prop("close_out_date", Schema.Date)
+      .prop("completed_by_contact_id", Schema.Picker)
+      .prop("actual_completion_date", Schema.Date)
+      .prop("hand_off_to_operations", Schema.Picker)
+      .prop("records_filed", Schema.Picker)
+      .prop("contract_ev_completed", Schema.Picker)
+      .prop("contractor_security_terminated", Schema.Picker)
+  ),
+};
+
 const updateOne = {
-  // Request parameters.
-  params: {
-    id: { type: "integer" },
-  },
+  params: Schema.IdParam,
   // Body validation.
-  body: {
-    type: "object",
-    properties: {
-      // Registration
-      project_number: requiredStringValidation,
-      project_name: requiredStringValidation,
-      project_version: optionalStringValidation,
-      ministry_id: { type: "integer" },
-      initiation_date: { type: "string", format: "date-time" },
-      portfolio_id: { type: "integer" },
-      planned_start_date: { type: "string", format: "date-time" },
-      fiscal: { type: "integer" },
-      planned_end_date: { type: "string", format: "date-time" },
-      planned_budget: { type: "number" },
-      project_type: optionalStringValidation,
-      funding: optionalStringValidation,
-      total_project_budget: { type: "number" },
-      recoverable: optionalStringValidation,
-      recoverable_amount: { type: "number" },
-      // Agreement
-      agreement_type: { enum: ["Project Charter", "Other", "Partnership Agreement", "MOU", null] },
-      agreement_start_date: { type: "string", format: "date-time" },
-      agreement_signed_date: { type: "string", format: "date-time" },
-      agreement_end_date: { type: "string", format: "date-time" },
-      description: { type: "string" },
-      notes: { type: "string" },
-      // Close Out
-      close_out_date: { type: "string", format: "date-time" },
-      completed_by_contact_id: { type: "integer", minimum: 0 },
-      actual_completion_date: { type: "string", format: "date-time" },
-      hand_off_to_operations: { enum: yesNoEnum },
-      records_filed: { enum: yesNoEnum },
-      contract_ev_completed: { enum: yesNoEnum },
-      contractor_security_terminated: { enum: yesNoEnum },
-    },
-  },
+  body: requestSingleBody,
+  response: getUpdateResponse(),
 };
 
 module.exports = {
+  getAll,
   getOne,
+  getOneCloseOut,
   updateOne,
 };

--- a/backend/src/validators/projects.js
+++ b/backend/src/validators/projects.js
@@ -106,8 +106,7 @@ const getOneCloseOut = {
 
 const updateOne = {
   params: Schema.IdParam,
-  // Body validation.
-  body: requestSingleBody,
+  body: requestSingleBody.minProperties(1),
   response: getUpdateResponse(),
 };
 

--- a/backend/src/validators/users.js
+++ b/backend/src/validators/users.js
@@ -25,7 +25,7 @@ const addOne = {
 };
 
 const updateOne = {
-  body: baseBody.without(["id"]),
+  body: baseBody.without(["id"]).minProperties(1),
   response: getUpdateResponse,
 };
 

--- a/backend/src/validators/users.js
+++ b/backend/src/validators/users.js
@@ -1,30 +1,40 @@
+const { Schema, getResponse, getAddResponse, getUpdateResponse } = require("./common_schema.js");
+const S = require("fluent-json-schema");
+
+const baseBody = S.object()
+  .prop("id", Schema.Id)
+  .prop("name", Schema.ShortString)
+  .prop("email", Schema.RequiredEmail)
+  .prop("role_id", Schema.Id);
+
+const getAll = {
+  response: getResponse(
+    S.array().items(baseBody.without(["role_id"]).prop("display_name", Schema.ShortString))
+  ),
+};
+
 const getOne = {
-  params: {
-    id: { type: "integer" },
-  },
+  params: Schema.IdParam,
+  response: getResponse(baseBody.prop("role_id", Schema.Picker)),
 };
 
 const addOne = {
-  headers: {
-    type: "object",
-    properties: {
-      Authorization: { type: "string" },
-    },
-  },
-  body: {
-    type: "object",
-    required: ["email", "name", "role_id"],
-    properties: {
-      name: { type: "string" },
-      email: { type: "string", format: "email" },
-      role_id: { type: "integer" },
-    },
-  },
+  headers: S.object().prop("Authorization", S.string()),
+  body: baseBody.without(["id"]).required(["email", "name", "role_id"]),
+  response: getAddResponse,
 };
+
+const updateOne = {
+  body: baseBody.without(["id"]),
+  response: getUpdateResponse,
+};
+
 const deleteOne = getOne;
 
 module.exports = {
+  getAll,
   getOne,
   addOne,
+  updateOne,
   deleteOne,
 };

--- a/backend/test/routes/contacts.test.js
+++ b/backend/test/routes/contacts.test.js
@@ -42,17 +42,15 @@ describe("Access contacts routes with valid contacts", () => {
   });
 
   it("Should get a list of contacts when you hit /contacts", async () => {
-    contactsModel.findAll.mockResolvedValue(contacts);
+    contactsModel.findAll.mockResolvedValue(contacts.contacts);
     const response = await app.inject({
       method: "GET",
       url: "/contacts",
     });
     const responseBody = JSON.parse(response.body);
     expect(response.statusCode).toBe(200);
-    expect(responseBody.data.contacts).toBeInstanceOf(Array);
-    responseBody.data.contacts.forEach((contactsObject) =>
-      expect("id" in contactsObject).toBe(true)
-    );
+    expect(responseBody.data).toBeInstanceOf(Array);
+    responseBody.data.forEach((contactsObject) => expect("id" in contactsObject).toBe(true));
   });
 });
 

--- a/backend/test/routes/projects.test.js
+++ b/backend/test/routes/projects.test.js
@@ -1,6 +1,7 @@
 const serverConfig = require("../../src/facilities/fastify");
 const authHelper = require("../../src/facilities/keycloak");
 const projectsModel = require("../../src/models/projects.js");
+const contractsModel = require("../../src/models/contracts");
 let app;
 
 // Mock authentication so we can test routes themselves.
@@ -59,7 +60,8 @@ describe("Access projects routes with valid user", () => {
   });
 
   it("Should get a single project object when you hit /api/project/:id with a valid ID", async () => {
-    projectsModel.findById.mockResolvedValue({ id: 1 });
+    projectsModel.findById.mockResolvedValue({ project_number: "P1" });
+    contractsModel.findByProjectId.mockResolvedValue([]);
     const response = await app.inject({
       method: "GET",
       url: "/projects/1",
@@ -67,11 +69,12 @@ describe("Access projects routes with valid user", () => {
 
     const responseBody = JSON.parse(response.body);
     expect(response.statusCode).toBe(200);
-    expect("id" in responseBody.data).toBe(true);
+    expect("project_number" in responseBody.data).toBe(true);
   });
 
   it("Should get a single project close out object when you hit /api/project/:id/close-out with a valid ID", async () => {
-    projectsModel.findCloseOutById.mockResolvedValue({ id: 1 });
+    projectsModel.findCloseOutById.mockResolvedValue({ close_out_date: "1" });
+    contractsModel.findByProjectId.mockResolvedValue([]);
     const response = await app.inject({
       method: "GET",
       url: "/projects/1/close-out",
@@ -79,7 +82,7 @@ describe("Access projects routes with valid user", () => {
 
     const responseBody = JSON.parse(response.body);
     expect(response.statusCode).toBe(200);
-    expect("id" in responseBody.data).toBe(true);
+    expect("close_out_date" in responseBody.data).toBe(true);
   });
 });
 

--- a/frontend/src/pages/Admin/Contacts/index.tsx
+++ b/frontend/src/pages/Admin/Contacts/index.tsx
@@ -97,6 +97,7 @@ export const Contacts: FC = () => {
     { width: "half", title: "Postal Code", value: contactQuery?.data?.postal },
     { width: "half", title: "Mobile Phone", value: contactQuery?.data?.mobile },
     { width: "half", title: "Website", value: contactQuery?.data?.website },
+    { width: "half", title: "Email", value: contactQuery?.data?.email },
     { width: "half", title: "Notes", value: contactQuery?.data?.notes },
   ];
 


### PR DESCRIPTION
Adam and I had discussed using yup as the validation engine on the backend since that's what's recommended by Formik to validate input on the frontend. I found that in Fastify yup can only be used for input validation, not response serialization so we'd need to create two sets of schema: one for yup validation and one for AJV serialization (the default in Fastify). Instead I went with only AJV so we only need one set of schema. I also found that it's possible to use AJV with Formik which might be something to look into.