### PR TITLE
fix ts compile-time bug by re-adding an <any> type to useQuery invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**August 22, 2023**
+- Frontend
+  - revert changes to typescript `<any>` type on the useQuery hook that caused a TS compiler error
+
 **August 22, 2023 [DESCW-1281](https://apps.itsm.gov.bc.ca/jira/browse/DESCW-1281)**
 
 - Frontend

--- a/frontend/src/hooks/useFormatTableData.tsx
+++ b/frontend/src/hooks/useFormatTableData.tsx
@@ -97,7 +97,10 @@ export const useFormatTableData = ({
 
   // Queries
   //Destructure the keycloak functionality
-  const { data, isLoading } = useQuery([apiEndPoint], getTableData, {
+  /* eslint "no-warning-comments": [1, { "terms": ["todo", "fixme"] }] */
+  // todo: Define a good type. "Any" type temporarily permitted.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, isLoading } = useQuery<any>([apiEndPoint], getTableData, {
     refetchOnMount: "always",
   });
   return { data, isLoading };


### PR DESCRIPTION

fixes typescript error caused by removing an <any> type from a `useQuery` invocation