### PR TITLE
descw-2037 fix model and formconfig to display program area name

### DIFF
--- a/backend/src/models/projects/journal_voucher.js
+++ b/backend/src/models/projects/journal_voucher.js
@@ -43,9 +43,17 @@ const findById = (id) => {
       knex.raw(
         "(SELECT json_build_object('value', jv.fiscal_year_id, 'label', fiscal_year.fiscal_year)) AS fiscal_year_id"
       ),
-      knex.raw(
-        "(SELECT json_build_object('client', cc.client, 'responsibility_centre', cc.responsibility_centre, 'service_line', cc.service_line, 'stob', cc.stob, 'project_code', cc.project_code, 'client_amount', cc.client_amount, 'value', cc.id)) AS client_coding_id"
-      )
+      knex.raw(`(
+          SELECT json_build_object(
+            'program_area', cc.program_area,
+            'client', cc.client,
+            'responsibility_centre', cc.responsibility_centre,
+            'service_line', cc.service_line,
+            'stob', cc.stob,
+            'project_code', cc.project_code,
+            'client_amount', cc.client_amount,
+            'value', cc.id)
+            ) AS client_coding_id`)
     )
     .from(jvTable)
     .leftJoin(fiscalYearTable, { "jv.fiscal_year_id": `${fiscalYearTable}.id` })

--- a/frontend/src/pages/Projects/Project/Billing/FormConfig.ts
+++ b/frontend/src/pages/Projects/Project/Billing/FormConfig.ts
@@ -55,7 +55,7 @@ export const FormConfig = (query: UseQueryResult<AxiosResponse, unknown>) => {
         {
           width: "half",
           title: "Program Area",
-          value: query?.data?.data?.data?.client_coding_id?.client,
+          value: query?.data?.data?.data?.client_coding_id?.program_area,
         },
         {
           width: "full",


### PR DESCRIPTION
- model was missing program_area
- formconfig was using client instead of program area from model
- formconfig's autocompletetable field was correct. It just relied on a model whose option for program area JSON value but no program_area for the label.